### PR TITLE
Fix error with closing heart failure left panel

### DIFF
--- a/heart_index.html
+++ b/heart_index.html
@@ -380,7 +380,7 @@
 		zincRenderer.getThreeJSRenderer().setClearColor( 0xffffff, 0);
 		var halfHeartFlag = false;
 		var leftPanelIDs = ["initialNormal", "leftHeartElectricity", "leftHeartArrhythmia", "leftHeartAttack",
-			"leftModerateAttack", "leftSevereAttack", "leftHeartFailure"];
+			"leftModerateAttack", "leftSevereAttack", "leftHeartFailure", "leftCompensatedFailure", "leftDecompensatedFailure"];
 		var idleTime = 0;
 		var idleTimeLimit = 120000;
 		var oldTime = new Date();


### PR DESCRIPTION
Forgot to add the two additional left panels to the IDs, won't close when pressing home or any other disease icons. 
